### PR TITLE
add req_status property to client

### DIFF
--- a/elsapy/elsclient.py
+++ b/elsapy/elsclient.py
@@ -69,7 +69,12 @@ class ElsClient:
     def local_dir(self):
         """Gets the currently configured local path to write data to."""
         return self._local_dir
-    
+
+    @property
+    def req_status(self):
+    	'''Return the status of the request response, '''
+    	return {'status_code': self._status_code, 'status_msg': self._status_msg}
+
     @local_dir.setter
     def local_dir(self, path_str):
         """Sets the local path to write data to."""
@@ -103,7 +108,10 @@ class ElsClient:
             headers = headers
             )
         self.__ts_last_req = time.time()
+        self._status_code=r.status_code
         if r.status_code == 200:
+            self._status_msg='data retrieved'
             return json.loads(r.text)
         else:
+            self._status_msg="HTTP " + str(r.status_code) + " Error from " + URL + " and using headers " + str(headers) + ": " + r.text
             raise requests.HTTPError("HTTP " + str(r.status_code) + " Error from " + URL + "\nand using headers " + str(headers) + ":\n" + r.text)


### PR DESCRIPTION
The response is only returned as True or False, which is too vague. Add the req_status property to the client, so the status code and msg can be recorded for the exceptions. Useful for further handling.

Examples of results returned:
- {'status_code': 200, 'status_msg': 'data retrieved'}
- {'status_code': 404, 'status_msg': 'HTTP 404 Error from https://api.elsevier.com/content/abstract/SCOPUS_ID/84835457 and using headers {\'X-ELS-APIKey\': \'4***f9\', \'User-Agent\': \'elsapy-v0.3.2\', \'Accept\': \'application/json\'}: {"service-error":{"status":{"statusCode":"RESOURCE_NOT_FOUND","statusText":"The resource specified cannot be found."}}}\n'}