### PR TITLE
fix casing in __uri_base

### DIFF
--- a/elsapy/elsprofile.py
+++ b/elsapy/elsprofile.py
@@ -92,7 +92,7 @@ class ElsAuthor(ElsProfile):
     
     # static variables
     __payload_type = u'author-retrieval-response'
-    __uri_base = u'https://api.elsevier.com/content/author/AUTHOR_ID/'
+    __uri_base = u'https://api.elsevier.com/content/author/author_id/'
 
     # constructors
     def __init__(self, uri = '', author_id = ''):


### PR DESCRIPTION
`curl -X GET --header 'Accept: text/xml' 'https://api.elsevier.com/content/author/author_id/22988279600?apiKey=...'` works
`curl -X GET --header 'Accept: text/xml' 'https://api.elsevier.com/content/author/AUTHOR_ID/22988279600?apiKey=...'` returns 405