### PR TITLE
Add a missing comma to the end of the long description line

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     name = 'elsapy',
     version = version,
     description = "A Python module for use with Elsevier's APIs: Scopus, ScienceDirect, others - see https://api.elsevier.com",
-    long_description = "See https://github.com/ElsevierDev/elsapy for the latest information / background to this project."
+    long_description = "See https://github.com/ElsevierDev/elsapy for the latest information / background to this project.",
     author = 'Elsevier, Inc.',
     author_email = 'integrationsupport@elsevier.com',
     url = 'https://github.com/ElsevierDev/elsapy',


### PR DESCRIPTION
There's a syntax error in setup.py. This commit is to fix it. 