### PR TITLE
add a comma after long_description in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     name = 'elsapy',
     version = version,
     description = "A Python module for use with Elsevier's APIs: Scopus, ScienceDirect, others - see https://api.elsevier.com",
-    long_description = "See https://github.com/ElsevierDev/elsapy for the latest information / background to this project."
+    long_description = "See https://github.com/ElsevierDev/elsapy for the latest information / background to this project.",
     author = 'Elsevier, Inc.',
     author_email = 'integrationsupport@elsevier.com',
     url = 'https://github.com/ElsevierDev/elsapy',


### PR DESCRIPTION
Added a comma after the `long_description` field in setup.py. Developer install `pip install -e` from the cloned repo fails without fixing this. 