### PR TITLE
Add missing requirement `pandas` to `install_requires`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,5 +21,5 @@ setup(
         'Programming Language :: Python :: 3',
     ],
     packages = find_packages(exclude=['contrib', 'docs', 'tests*']),
-    install_requires = ['requests']
+    install_requires = ['requests', 'pandas']
 )


### PR DESCRIPTION
After a fresh install and setup of `elapsy`, I directly encountered the error message `ModuleNotFoundError: No module named 'pandas'`. Checking `setup.py`, I noticed that, in fact, there's only a requirement for `requests`.

This pull request fixes this, adss `pandas` to the `install_requires` section of `setup.py`