### PR TITLE
Wrap reading and setting of `insttoken` into a try/except

### DIFF
--- a/exampleProg.py
+++ b/exampleProg.py
@@ -1,11 +1,12 @@
 """An example program that uses the elsapy module"""
 
-from elsapy.elsclient import ElsClient
-from elsapy.elsprofile import ElsAuthor, ElsAffil
-from elsapy.elsdoc import FullDoc, AbsDoc
-from elsapy.elssearch import ElsSearch
 import json
-    
+
+from elsapy.elsclient import ElsClient
+from elsapy.elsdoc import AbsDoc, FullDoc
+from elsapy.elsprofile import ElsAffil, ElsAuthor
+from elsapy.elssearch import ElsSearch
+
 ## Load configuration
 con_file = open("config.json")
 config = json.load(con_file)
@@ -13,94 +14,100 @@ con_file.close()
 
 ## Initialize client
 client = ElsClient(config['apikey'])
-client.inst_token = config['insttoken']
+try:
+    # If you don't have a valid insttoken (which you would have received from
+    # Elsevier support staff), delete the placeholder text. If you enter a
+    # dummy value, your API requests will fail.
+    client.inst_token = config['insttoken']
+except KeyError:
+    pass
 
 ## Author example
 # Initialize author with uri
 my_auth = ElsAuthor(
-        uri = 'https://api.elsevier.com/content/author/author_id/7004367821')
+        uri='https://api.elsevier.com/content/author/author_id/7004367821')
 # Read author data, then write to disk
 if my_auth.read(client):
-    print ("my_auth.full_name: ", my_auth.full_name)
+    print("my_auth.full_name: ", my_auth.full_name)
     my_auth.write()
 else:
-    print ("Read author failed.")
+    print("Read author failed.")
 
 ## Affiliation example
 # Initialize affiliation with ID as string
-my_aff = ElsAffil(affil_id = '60101411')
+my_aff = ElsAffil(affil_id='60101411')
 if my_aff.read(client):
-    print ("my_aff.name: ", my_aff.name)
+    print("my_aff.name: ", my_aff.name)
     my_aff.write()
 else:
-    print ("Read affiliation failed.")
+    print("Read affiliation failed.")
 
 ## Scopus (Abtract) document example
 # Initialize document with ID as integer
-scp_doc = AbsDoc(scp_id = 84872135457)
+scp_doc = AbsDoc(scp_id=84872135457)
 if scp_doc.read(client):
-    print ("scp_doc.title: ", scp_doc.title)
-    scp_doc.write()   
+    print("scp_doc.title: ", scp_doc.title)
+    scp_doc.write()
 else:
-    print ("Read document failed.")
+    print("Read document failed.")
 
 ## ScienceDirect (full-text) document example using PII
-pii_doc = FullDoc(sd_pii = 'S1674927814000082')
+pii_doc = FullDoc(sd_pii='S1674927814000082')
 if pii_doc.read(client):
-    print ("pii_doc.title: ", pii_doc.title)
-    pii_doc.write()   
+    print("pii_doc.title: ", pii_doc.title)
+    pii_doc.write()
 else:
-    print ("Read document failed.")
+    print("Read document failed.")
 
 ## ScienceDirect (full-text) document example using DOI
-doi_doc = FullDoc(doi = '10.1016/S1525-1578(10)60571-5')
+doi_doc = FullDoc(doi='10.1016/S1525-1578(10)60571-5')
 if doi_doc.read(client):
-    print ("doi_doc.title: ", doi_doc.title)
-    doi_doc.write()   
+    print("doi_doc.title: ", doi_doc.title)
+    doi_doc.write()
 else:
-    print ("Read document failed.")
-
+    print("Read document failed.")
 
 ## Load list of documents from the API into affilation and author objects.
 # Since a document list is retrieved for 25 entries at a time, this is
 #  a potentially lenghty operation - hence the prompt.
-print ("Load documents (Y/N)?")
+print("Load documents (Y/N)?")
 s = input('--> ')
 
 if (s == "y" or s == "Y"):
 
     ## Read all documents for example author, then write to disk
     if my_auth.read_docs(client):
-        print ("my_auth.doc_list has " + str(len(my_auth.doc_list)) + " items.")
+        print("my_auth.doc_list has " + str(len(my_auth.doc_list)) + " items.")
         my_auth.write_docs()
     else:
-        print ("Read docs for author failed.")
+        print("Read docs for author failed.")
 
     ## Read all documents for example affiliation, then write to disk
     if my_aff.read_docs(client):
-        print ("my_aff.doc_list has " + str(len(my_aff.doc_list)) + " items.")
+        print("my_aff.doc_list has " + str(len(my_aff.doc_list)) + " items.")
         my_aff.write_docs()
     else:
-        print ("Read docs for affiliation failed.")
+        print("Read docs for affiliation failed.")
 
 ## Initialize author search object and execute search
-auth_srch = ElsSearch('authlast(keuskamp)','author')
+auth_srch = ElsSearch('authlast(keuskamp)', 'author')
 auth_srch.execute(client)
-print ("auth_srch has", len(auth_srch.results), "results.")
+print("auth_srch has", len(auth_srch.results), "results.")
 
 ## Initialize affiliation search object and execute search
-aff_srch = ElsSearch('affil(amsterdam)','affiliation')
+aff_srch = ElsSearch('affil(amsterdam)', 'affiliation')
 aff_srch.execute(client)
-print ("aff_srch has", len(aff_srch.results), "results.")
+print("aff_srch has", len(aff_srch.results), "results.")
 
 ## Initialize doc search object using Scopus and execute search, retrieving 
 #   all results
-doc_srch = ElsSearch("AFFIL(dartmouth) AND AUTHOR-NAME(lewis) AND PUBYEAR > 2011",'scopus')
-doc_srch.execute(client, get_all = True)
-print ("doc_srch has", len(doc_srch.results), "results.")
+doc_srch = ElsSearch(
+    "AFFIL(dartmouth) AND AUTHOR-NAME(lewis) AND PUBYEAR > 2011", 'scopus')
+doc_srch.execute(client, get_all=True)
+print("doc_srch has", len(doc_srch.results), "results.")
 
 ## Initialize doc search object using ScienceDirect and execute search, 
 #   retrieving all results
-doc_srch = ElsSearch("star trek vs star wars",'sciencedirect')
-doc_srch.execute(client, get_all = False)
-print ("doc_srch has", len(doc_srch.results), "results.")
+doc_srch = ElsSearch("star trek vs star wars", 'sciencedirect')
+doc_srch.execute(client, get_all=False)
+print("doc_srch has", len(doc_srch.results), "results.")


### PR DESCRIPTION
According to the docs at [`create a config file and add your APIkey`](https://github.com/ElsevierDev/elsapy/blob/master/CONFIG.md), if we don't have an `insttoken`, we should leave it out of the config file. However, the example program then fails as it tries to access key `insttoken` of the loaded json object.

This pull request fixes this by wrapping reading the `insttoken` value into a `try/except` block