### PR TITLE
Patch/rename config json to elsapy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .cache
-config.json
+elapsy.json
 niso_training_prog.py
 test_elsapy.py
 dump.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .cache
-elapsy.json
+elsapy.json
 niso_training_prog.py
 test_elsapy.py
 dump.json

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -1,7 +1,7 @@
 # configuration
 If you are using (or adapting) exampleProg.py, do this:
-- In the folder in which exampleProg.py resides, create a file called 'config.json'
-- Open 'config.json' in a file editor, and insert the following:
+- In the folder in which exampleProg.py resides, create a file called 'j'
+- Open 'elapsy.json' in a file editor, and insert the following:
 
     ```
     {
@@ -13,4 +13,4 @@ If you are using (or adapting) exampleProg.py, do this:
 - Paste your APIkey (obtained from http://dev.elsevier.com) in the right place
 - If you don't have a valid insttoken (which you would have received from Elsevier support staff), delete the placeholder text. If you enter a dummy value, your API requests will fail.
 
-The '.gitignore' file lists 'config.json' as a file to be ignored when committing elsapy to a GIT repository, which is to prevent your APIkey from being shared with the world. Make similar provisions when you change your configuration setup.
+The '.gitignore' file lists 'elapsy.json' as a file to be ignored when committing elsapy to a GIT repository, which is to prevent your APIkey from being shared with the world. Make similar provisions when you change your configuration setup.

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -1,7 +1,7 @@
 # configuration
 If you are using (or adapting) exampleProg.py, do this:
 - In the folder in which exampleProg.py resides, create a file called 'j'
-- Open 'elapsy.json' in a file editor, and insert the following:
+- Open 'elsapy.json' in a file editor, and insert the following:
 
     ```
     {
@@ -13,4 +13,4 @@ If you are using (or adapting) exampleProg.py, do this:
 - Paste your APIkey (obtained from http://dev.elsevier.com) in the right place
 - If you don't have a valid insttoken (which you would have received from Elsevier support staff), delete the placeholder text. If you enter a dummy value, your API requests will fail.
 
-The '.gitignore' file lists 'elapsy.json' as a file to be ignored when committing elsapy to a GIT repository, which is to prevent your APIkey from being shared with the world. Make similar provisions when you change your configuration setup.
+The '.gitignore' file lists 'elsapy.json' as a file to be ignored when committing elsapy to a GIT repository, which is to prevent your APIkey from being shared with the world. Make similar provisions when you change your configuration setup.

--- a/exampleProg.py
+++ b/exampleProg.py
@@ -7,7 +7,7 @@ from elsapy.elssearch import ElsSearch
 import json
     
 ## Load configuration
-con_file = open("elapsy.json")
+con_file = open("elsapy.json")
 config = json.load(con_file)
 con_file.close()
 

--- a/exampleProg.py
+++ b/exampleProg.py
@@ -7,7 +7,7 @@ from elsapy.elssearch import ElsSearch
 import json
     
 ## Load configuration
-con_file = open("config.json")
+con_file = open("elapsy.json")
 config = json.load(con_file)
 con_file.close()
 

--- a/test_elsapy.py
+++ b/test_elsapy.py
@@ -13,7 +13,7 @@ from urllib.parse import quote_plus as url_encode
 import json, pathlib
 
 ## Load good client configuration
-conFile = open("config.json")
+conFile = open("elapsy.json")
 config = json.load(conFile)
 conFile.close()
 

--- a/test_elsapy.py
+++ b/test_elsapy.py
@@ -13,7 +13,7 @@ from urllib.parse import quote_plus as url_encode
 import json, pathlib
 
 ## Load good client configuration
-conFile = open("elapsy.json")
+conFile = open("elsapy.json")
 config = json.load(conFile)
 conFile.close()
 


### PR DESCRIPTION
To remove ambiguity from the configuration of elapsy, I suggest renaming the original `config.json` file to `elsapy.json`. This way, the file name is more verbose and there's also less chance of colliding with other configuration files of other python packages/modules/apps.