### PR TITLE
added optional log functionality

### DIFF
--- a/elsapy/__init__.py
+++ b/elsapy/__init__.py
@@ -8,3 +8,24 @@
     * https://api.elsevier.com"""
 
 version = '0.5.0'
+
+
+from .log_util import LOGGERS, add_file_handle_to_logger
+
+
+def log_to_directory(dirpath, logger_names=None):
+    """
+    :param str dirpath: output directory where loggers will write into.
+    :param logger_names: Optional list of strings to identify the affected
+      loggers by the name given when created via ``get_logger``. If none
+      is given, all loggers will be affected.
+
+    When called, existing loggers will start logging their output to the
+    provided directory.
+    """
+    if logger_names is None:
+        logger_names = LOGGERS.keys()
+    assert all(ln in LOGGERS for ln in logger_names), \
+        f"Unknown loggers! {logger_names}"
+    for ln in logger_names:
+        add_file_handle_to_logger(LOGGERS[ln], dirpath)

--- a/elsapy/log_util.py
+++ b/elsapy/log_util.py
@@ -12,30 +12,59 @@ except ImportError:
 
 ## Following adapted from https://docs.python.org/3/howto/logging-cookbook.html
 
-def get_logger(name):
-    # TODO: add option to disable logging, without stripping logger out of all modules
-    #   - e.g. by simply not writing to file if logging is disabled. See
-    #   https://github.com/ElsevierDev/elsapy/issues/26
-    
+
+# A collection of singletons. Allows to e.g. manipulate file handles at runtime
+LOGGERS = {}
+
+
+def _make_logger(name):
+    """
+    .. note::
+
+      Do not call this function! To get a logger, use get_logger instead.
+    """
     # create logger with module name
     logger = logging.getLogger(name)
     logger.setLevel(logging.DEBUG)
-    # create log path, if not already there
-    logPath = Path('logs')
-    if not logPath.exists():
-        logPath.mkdir()
-    # create file handler which logs even debug messages
-    fh = logging.FileHandler('logs/elsapy-%s.log' % time.strftime('%Y%m%d'))
-    fh.setLevel(logging.DEBUG)
-    # create console handler with a higher log level
+    # create console handler with error log level
     ch = logging.StreamHandler()
     ch.setLevel(logging.ERROR)
-    # create formatter and add it to the handlers
-    formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
-    fh.setFormatter(formatter)
+    # create formatter and add it to the handler
+    formatter = logging.Formatter(
+        '%(asctime)s - %(name)s - %(levelname)s - %(message)s')
     ch.setFormatter(formatter)
-    # add the handlers to the logger
-    logger.addHandler(fh)
+    # add the handler to the logger
     logger.addHandler(ch)
-    logger.info("Module loaded.")
+    logger.info(f"Logger created: {name}")
     return logger
+
+
+def get_logger(name):
+    """
+    Returns a logger with the given name. If it doesn't exist, creates,
+    stores and returns the new logger.
+    """
+    if name not in LOGGERS:
+        LOGGERS[name] = _make_logger(name)
+    return LOGGERS[name]
+
+
+def add_file_handle_to_logger(lgr, output_dir):
+    """
+    :returns: None. This function adds a ``FileHandler`` to the given logger,
+      to write a log file inside the given ``output_dir``.
+    """
+    # create log path, if not already there
+    logPath = Path(output_dir)
+    if not logPath.exists():
+        logPath.mkdir()
+    # create file handler with debug log level
+    fh = logging.FileHandler(logPath / f'elsapy-{time.strftime("%Y%m%d")}.log')
+    fh.setLevel(logging.DEBUG)
+    # create formatter and add it to the handler
+    formatter = logging.Formatter(
+        '%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+    fh.setFormatter(formatter)
+    # add the handler to the logger
+    lgr.addHandler(fh)
+

--- a/exampleProg.py
+++ b/exampleProg.py
@@ -5,7 +5,12 @@ from elsapy.elsprofile import ElsAuthor, ElsAffil
 from elsapy.elsdoc import FullDoc, AbsDoc
 from elsapy.elssearch import ElsSearch
 import json
-    
+
+## Comment out if you don't want to log files
+import elsapy
+elsapy.log_to_directory("logs")
+
+
 ## Load configuration
 con_file = open("config.json")
 config = json.load(con_file)


### PR DESCRIPTION
This is a proposed PR to fix issue #26 (disabling logging).

Since a new logger is being created for several files when the lib is loaded, it is already late/cumbersome for the user to keep track of the internals and modify the logging behaviour. This proposed fix addresses this issue as follows:

1. Loggers are singletons inside the `log_util` namespace. This way we can keep track of all loggers in a centralized way. This is implemented by 
  a) using a dictionary to keep all logs 
  b) making the log creator a protected function and
  c) the log getter tries to fetch an existing singleton, and otherwise creates+returns one if it didn't exist

2. The module incorporates a `log_to_directory` function that provides the desired functionality to the specified loggers (or to all if none specified). I.e. default behaviour is not logging, and users can opt-in at any time and also provide their desired destiny. This function has been added to `__init__` in order to keep it more accessible to users.

The user simply has to add the following lines anywhere inside their application code:

```python
import elsapy
elsapy.log_to_directory("logs")
```

I think this is an improvement for the following reasons:
1. Most users won't like their filesystem to be populated without explicitly requesting so
2. If users want this functionality, this way they can also select the target directory
3. It is very easy for the users
4. It is fairly easy for the maintainers, and extendible: Further functionality (like e.g. *removing* file handlers) can be added in an analogous manner

Note that the use of a singleton is the least intrusive fix given that several modules are creating loggers as side effect when loaded.

Let me know what you think! Hope this helps.

Cheers,  
Andres
